### PR TITLE
Fix newer versions of MixinSquared breaking older versions

### DIFF
--- a/common.gradle
+++ b/common.gradle
@@ -58,7 +58,7 @@ dependencies {
 
 	include(modImplementation("me.fallenbreath:conditional-mixin-fabric:${project.conditionalmixin_version}"))
 	include(annotationProcessor(implementation("io.github.llamalad7:mixinextras-fabric:${project.mixinextras_version}")))
-	include(annotationProcessor(implementation("com.bawnorton.mixinsquared:mixinsquared-fabric:${project.mixinsquared_version}")))
+	include(annotationProcessor(implementation("com.github.bawnorton:mixinsquared-fabric:${project.mixinsquared_version}")))
 }
 
 String MIXIN_CONFIG_PATH = 'carpetpatcher.mixins.json'

--- a/common.gradle
+++ b/common.gradle
@@ -58,7 +58,7 @@ dependencies {
 
 	include(modImplementation("me.fallenbreath:conditional-mixin-fabric:${project.conditionalmixin_version}"))
 	include(annotationProcessor(implementation("io.github.llamalad7:mixinextras-fabric:${project.mixinextras_version}")))
-	include(annotationProcessor(implementation("com.github.bawnorton:mixinsquared-fabric:${project.mixinsquared_version}")))
+	include(annotationProcessor(implementation("com.github.bawnorton.mixinsquared:mixinsquared-fabric:${project.mixinsquared_version}")))
 }
 
 String MIXIN_CONFIG_PATH = 'carpetpatcher.mixins.json'


### PR DESCRIPTION
MixinSquared migrated from jitpack to my own maven when 0.2.0-beta.5 released, I did not know at the time that this would break compatibility with older versions of MixinSquared as the maven group changed from `com.github.bawnorton` to `com.bawnorton` causing mod loaders to think they were different mods. 

This PR reverts that change to allow for compatibility with older versions of MixinSquared.

 I aplogize for the inconvenience, I was not aware of the implications of this change.

_This PR was generated automatically_